### PR TITLE
Fix for vulnerability GHSA-cxww-7g56-2vh6 reported by GitHub on 2024-09-03

### DIFF
--- a/.github/workflows/_publish_package.yml
+++ b/.github/workflows/_publish_package.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: ./dist/

--- a/.github/workflows/_publish_package_test.yml
+++ b/.github/workflows/_publish_package_test.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: ./dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ## [Unreleased]
 
 ### Dependencies
+* Updated to download-artifact@v4  (from download-artifact@v3)
+
+### Dependencies
 * GitHub workflows: Replaced pip install tox with pip install tox-uv
 * GitHub workflows: Removed cache: 'pip' for tox-uv compatibility
 * GitHub workflows: Install dependencies: change singleline run statements to multiline run statements


### PR DESCRIPTION
- **Updated to download-artifact@v4  (from download-artifact@v3)**
- **updated CHANGELOG.md**

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Address a vulnerability by updating the GitHub Actions workflows to use download-artifact@v4, and update the CHANGELOG.md to document this change.

Enhancements:
- Update GitHub Actions workflows to use download-artifact@v4 instead of download-artifact@v3.

Documentation:
- Update CHANGELOG.md to reflect the change in the download-artifact version.

<!-- Generated by sourcery-ai[bot]: end summary -->